### PR TITLE
Get the latest repository code for test

### DIFF
--- a/docs/VH2017.js
+++ b/docs/VH2017.js
@@ -1,15 +1,29 @@
 window.addEventListener('load', InitializeUserAgent, true);
 
+
+
 VH2017 = {};
-VH2017.MainPanelUrl = "https://raw.githubusercontent.com/Visual-HTML/V-HTML/master/Sources/testmain.html";
-VH2017.PreviewPanelUrl = "https://raw.githubusercontent.com/Visual-HTML/V-HTML/master/Sources/Default/Article000.txt";
 VH2017.document={};
 VH2017.document.body={};
 VH2017.document.body.contentEditable={};
 VH2017.document.body.designMode={};
-VH2017.handlerKey = Date.now();
-VH2017.designerKey = Date.now();
 VH2017.currentTarget = null;
+VH2017.Clear = function() { 
+	document.body.removeAttribute("contentEditable");
+	document.removeEventListener('keydown', DocumentKeyDown, false);	
+	document.removeEventListener('click', DocumentClick, false);
+	
+    var _elements = document.querySelectorAll('*');
+	for (var i = 0 ; i < _elements.length ; i++) {
+		_elements[i].removeEventListener('click', ElementClick, false);
+		_elements[i].removeAttribute("data-VH2017-hndk");
+	}
+	
+};
+VH2017.ElementClick = function(evt) { };
+VH2017.ElementWrap = function(elt) { };
+
+
 
 function InitializeUserAgent(e) {
 	
@@ -17,217 +31,146 @@ function InitializeUserAgent(e) {
 }
 
 function InitializeDocument() {
+	
 	VH2017.document.body.contentEditable.InitalValue = document.body.contentEditable;
 	VH2017.document.body.designMode.InitialValue = document.designMode;
-	
-	document.body.addEventListener('click', BodyClicked, false);
-	
-	if (VH2017.document.body.designMode.InitialValue.toLowerCase === "Inherit") return;
-	
+		
+	document.addEventListener('keydown', DocumentKeyDown, false);	
+	document.body.addEventListener('click', DocumentClick, false);	
+
+    if (document.body.childElementCount === 0) {
+		var _res = document.body.appendChild(document.createElement("p"));
+		VH2017.currentTarget = _res;
+	} else {
+		 VH2017.currentTarget = document.body.firstChild;
+	}
+	 
 	InitializeContent();
+	
 }
 
-function InitializeContent() {
-	
-	var _autoBlank=false;
-	if (document.body.childNodes.length === 1) {
-		var _element = document.createElement("p");
-		_element.contentEditable = true;
-		document.body.appendChild(_element).focus();
-		_autoBlank=true;
-	}
-	
-    var _elements = document.body.querySelectorAll('*');
-	for (var i = 0 ; i < _elements.length ; i++) {
-		_elements[i].addEventListener('click', ElementClicked, false);
-		_elements[i].addEventListener('keydown', ReturnPressed, false);
-		_elements[i].style.border = "1px dashed gray";
-		_elements[i].setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-		_elements[i].contentEditable = true;
-	}
-	VH2017.handlerKey = Date.now();
-	
-	if (_autoBlank) !InitializeDesigner();
+
+
+function InitializeContent() {	
+
+	WrapElements();
+
+	VH2017.currentTarget.focus();
+	VH2017.currentTarget.click();
+
 }
 
-function InitializeDesigner(){	
-	
-	VH2017.designerKey = Date.now();
-	
-	var xReq = new XMLHttpRequest();
-	xReq.open("GET", VH2017.MainPanelUrl, true); 
-	xReq.timeout = 2000;
-	xReq.ontimeout = function () { };
-	xReq.onreadystatechange = function (e) {
-		if (xReq.readyState == 4) {         
-			if (xReq.status = "200") { 
-			    var _element = document.createElement("div");
-				_element.Id = Date.now();
-				_element.setAttribute("data-VH2017-dsgk",VH2017.designerKey);
-				_element.innerHTML = xReq.response;
-				document.body.appendChild(_element);
-				InitializeDesigner_Step1();
-				} else {
-				
-				}
-			}
-		}
-	xReq.send(null);
-}
 
-function InitializeDesigner_Step1() {
-	var xReq = new XMLHttpRequest();
-	xReq.open("GET", VH2017.PreviewPanelUrl, true); 
-	xReq.timeout = 2000;
-	xReq.ontimeout = function () { };
-	xReq.onreadystatechange = function (e) {
-		if (xReq.readyState == 4) {         
-			if (xReq.status = "200") { 
-			    var _element = document.createElement("div");
-				_element.Id = Date.now();
-				_element.setAttribute("data-VH2017-dsgk",VH2017.designerKey);
-				_element.style.position="fixed";
-				_element.style.right="0";
-				_element.style.width="320px";				
-				_element.style.height="480px";
-				_element.style.overflowX="scroll";
-				_element.innerHTML = xReq.response;
-				document.body.appendChild(_element);
-				} else {
-				
-				}
-			}
-		}
-	xReq.send(null);
-}
 
-function ElementClicked(e) {
-  e.stopPropagation();
-  e.preventDefault();
+function ElementKeyDown(e) { 
+         
+	console.log( e.type + " " + e.currentTarget.nodeName + " " +
+		(document.activeElement.nodeName ? document.activeElement.nodeName : null));
+	
+   if (e.which === 13) {	   
+	   	e.preventDefault();
+		e.stopPropagation();
+
+		var _elt = document.createElement("p");			
+		var _res = e.currentTarget.parentNode.insertBefore(_elt, e.currentTarget.nextElementSibling);
+		WrapElements(_res);
+   }
    
-  /* look for and attach unhandled child nodes */
-  for (var i = 0 ; i < e.currentTarget.childNodes.length ; i++) {
-	  if (e.currentTarget.childNodes[i].nodeType != 3 && 		 
-		  e.currentTarget.childNodes[i].getAttribute('data-VH2017-hndk') === null){ 
-		e.currentTarget.childNodes[i].addEventListener('click', ElementClicked, false);
-		e.currentTarget.childNodes[i].addEventListener('keydown', ReturnPressed, false);
-		e.currentTarget.childNodes[i].setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-		e.currentTarget.childNodes[i].style.border = "1px dashed gray";
-	  }
-  }
-
-  // a handle on current element is available in e.currentTarget
-  VH2017.currentTarget = e.currentTarget;
-  // now exposed to library code
 }
-function ReturnPressed(e) {
+
+
+
+function ElementClick(e) {
 	
-  if (e.which === 13) {
-	  e.preventDefault();
-	  
-	  /* look for and attach unhandled child nodes */
-	  for (var i = 0 ; i < e.currentTarget.childNodes.length ; i++) {
-		  if (e.currentTarget.childNodes[i].nodeType != 3 &&
-			  e.currentTarget.childNodes[i].getAttribute('data-VH2017-hndk') === null){ 
-			e.currentTarget.childNodes[i].addEventListener('click', ElementClicked, false);
-			e.currentTarget.childNodes[i].addEventListener('keydown', ReturnPressed, false);
-			e.currentTarget.childNodes[i].setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-			e.currentTarget.childNodes[i].style.border = "1px dashed gray";
+	console.log( e.type + " " + e.currentTarget.nodeName + " " +
+		(document.activeElement.nodeName ? document.activeElement.nodeName : null));
+	
+    e.stopPropagation();
+	e.preventDefault();
+	
+	VH2017.currentTarget = e.currentTarget;
+	VH2017.currentTarget.contentEditable = true;	
+	VH2017.currentTarget.focus();
+	
+	VH2017.ElementClick(e);
+
+}
+
+
+
+function ElementFocusOut(e) {
+	
+	console.log( e.type + " " + e.currentTarget.nodeName + " " +
+		(document.activeElement.nodeName ? document.activeElement.nodeName : null));
+	
+	e.currentTarget.removeAttribute("contentEditable");
+
+}
+
+
+
+function DocumentClick(e) {
+	
+	console.log( e.type + " " + e.currentTarget.nodeName + " " +
+		(document.activeElement.nodeName ? document.activeElement.nodeName : null));
+	
+}
+
+
+
+function DocumentKeyDown(e) { 
+	
+	console.log( e.type + " " + e.currentTarget.nodeName + " " +
+		(document.activeElement.nodeName ? document.activeElement.nodeName : null));
+	
+   if (e.which === 13) {
+	   
+	   if (document.body.hasAttribute("contentEditable")) {
+	       WrapElements(); 
+	
+		} else {
+			e.preventDefault();
+			
+			var _res = document.body.appendChild(document.createElement("p"));
+			WrapElements(_res);
+		}
+   }
+}
+
+
+
+function WrapElements(elt) {
+	
+	if (typeof(elt) === "undefined") {
+			
+		// look for and attach unhandled elements
+		var _elements = document.body.querySelectorAll('body *:not([data-VH2017-hndk])');
+		
+		for (var i = 0 ; i < _elements.length ; i++) {
+		  if ( _elements[i].nodeType === 1 
+						 && !_elements[i].hasAttribute("data-VH2017-dsgk")
+						 && !_elements[i].hasAttribute('data-VH2017-hndk') ) { 
+			_elements[i].addEventListener('keydown', ElementKeyDown, false);
+			_elements[i].addEventListener('click', ElementClick, false);
+			_elements[i].addEventListener('focusout', ElementFocusOut, false); 
+			_elements[i].setAttribute("data-VH2017-hndk","");
+			VH2017.ElementWrap(_elements[i]);
 		  }
-	  }
-	  
-	  var _element = document.createElement("p");
-	  
-		_element.addEventListener('click', ElementClicked, false);
-		_element.addEventListener('keydown', ReturnPressed, false);
-		_element.setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-		_element.style.border = "1px dashed gray";
+		}
+	
+	} else {
 		
-		_element.contentEditable = true;
-		document.body.appendChild(_element).focus();
-  }
-}
-
-function BodyClicked(e) {
-  e.stopPropagation();
-  e.preventDefault();
-   
-  /* look for and attach unhandled child nodes */
-  for (var i = 0 ; i < e.currentTarget.childNodes.length ; i++) {
-	  if (e.currentTarget.childNodes[i].nodeType != 3 &&  
-		  e.currentTarget.childNodes[i].getAttribute('data-VH2017-dsgk') === null &&	
-		  e.currentTarget.childNodes[i].getAttribute('data-VH2017-hndk') === null){ 
-		e.currentTarget.childNodes[i].addEventListener('click', ElementClicked, false);
-		e.currentTarget.childNodes[i].addEventListener('keydown', ReturnPressed, false);
-		e.currentTarget.childNodes[i].setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-		e.currentTarget.childNodes[i].style.border = "1px dashed gray";
-		e.currentTarget.childNodes[i].setAttribute("contentEditable","true");
-	  }
-  }
-
-  // a handle on current element is available in e.currentTarget
-  //VH2017.currentTarget = e.currentTarget;
-  // now exposed to library code
-}
-
-function ReplaceNode(elt, tagName) {
+		elt.addEventListener('keydown', ElementKeyDown, false);
+		elt.addEventListener('click', ElementClick, false);
+		elt.addEventListener('focusout', ElementFocusOut, false); 
+		elt.setAttribute("data-VH2017-hndk","");
 	
-	if (elt == null) return;
-	
-	_element = document.createElement(tagName);
-	_element.innerHTML = elt.innerHTML;
-	_element.contentEditable = true;
-	
-	for(var i = 0 ; i < elt.classList.length ; i++) {
-	_element.classList.add(elt.classList[i]);
-	}
-	
-	_element.style.textAlign = elt.style.textAlign;
-	_element.addEventListener('click', ElementClicked, false);
-	_element.addEventListener('keydown', ReturnPressed, false);
-	_element.setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-	_element.style.border = "1px dashed gray";
-				
-	elt.parentNode.replaceChild(_element,elt);
-	
-	_element.focus();
-	_element.click();
-	
-}
-
-
-
-
-function Align(elt, align) {
-	
-	if (elt == null) return;
+		VH2017.currentTarget = elt;
+		VH2017.ElementWrap(elt);
+		elt.contentEditable = true;
+		VH2017.currentTarget.focus();
 		
-	elt.style.textAlign = align;
-	
-	elt.focus();
-	elt.click();
-	
-}
-
-
-function injectHTML(e) {
-	
-var _element = document.createElement("div");
-_element.Id = Date.now();
-_element.setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-_element.innerHTML = e.currentTarget.innerHTML;
-
-VH2017.currentTarget.appendChild(_element);
-
-var _elements = VH2017.currentTarget.querySelectorAll('*');
-	for (var i = 0 ; i < _elements.length ; i++) {
-		_elements[i].addEventListener('click', ElementClicked, false);
-		_elements[i].addEventListener('keydown', ReturnPressed, false);
-		_elements[i].style.border = "1px dashed gray";
-		_elements[i].setAttribute("data-VH2017-hndk",VH2017.handlerKey);
-		
-		//can't explain why but here it not needed to set it !, if set it switch to the IE design mode ?
-		//_elements[i].setAttribute("contentEditable","true");
 	}
 	
 }
+


### PR DESCRIPTION
- contentEditable managed at element level (at body level it introduce behaviors out of the editor' wrapper logic)
- start on blank page with cursor blinking, ready to get text input
- can start on a document with html code in the body, all elements wrapped
- wrapping logic: only one element is set contentEditable (click/focusout events) at a time
- editing function add/insert content next (using return)